### PR TITLE
Disable dropdown option

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -82,7 +82,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "demo-app:build"
+            "browserTarget": "demo-app:build",
+            "port": 4201
           },
           "configurations": {
             "production": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-style-guide",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "license": "MIT",
   "author": {
     "email": "garethdn@gmail.com",

--- a/src/_lib/modules/dropdowns/dropdown.directive.ts
+++ b/src/_lib/modules/dropdowns/dropdown.directive.ts
@@ -1,6 +1,7 @@
 import { Directive, Input, HostBinding, OnDestroy, OnInit, OnChanges, SimpleChanges, ElementRef, Output, EventEmitter, NgZone, Renderer2, ChangeDetectorRef } from '@angular/core';
 import { DropdownService } from "./dropdown.service";
 import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 
 @Directive({
     selector: '[nwDropdown]',
@@ -12,6 +13,8 @@ export class DropdownDirective implements OnInit, OnChanges, OnDestroy {
     @Input() autoClose: boolean | "inside" | "outside" = true;
     @Input() elementsToIgnore: HTMLElement[] = [];
     @Input() selectorsToIgnore: string[] = [];
+    @HostBinding('class.disabled')
+    @Input() disabled: boolean = false;
 
     @Output() opened: EventEmitter<null> = new EventEmitter();
     @Output() closed: EventEmitter<null> = new EventEmitter();
@@ -61,15 +64,17 @@ export class DropdownDirective implements OnInit, OnChanges, OnDestroy {
     }
 
     private _subscribeToToggle(): void {
-        this._toggleSubscription = this._service.toggle$.subscribe(isOpen => {
-            this.isOpen = isOpen;
+        this._toggleSubscription = this._service.toggle$
+            .pipe(filter(() => !this.disabled))
+            .subscribe(isOpen => {
+                this.isOpen = isOpen;
 
-            if (this.isOpen) {
-                this.opened.emit();
-            } else {
-                this.closed.emit();
-            }
-        });
+                if (this.isOpen) {
+                    this.opened.emit();
+                } else {
+                    this.closed.emit();
+                }
+            });
     }
 
     onDocumentClick(event: MouseEvent) {


### PR DESCRIPTION
This is usually not an issue with a top-level dropdown that is opened by clicking a button. In that case, we will usually disable the button, preventing the click from being registered and preventing the dropdown from opening.

For nested dropdowns, the dropdown toggle is usually bound to a `li` element, upon which the `disabled` attribute does nothing. The result is that we have no way of preventing nested dropdowns from opening.