### PR TITLE
RDN-917 responsive dropdown toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nw-style-guide",
-  "version": "14.2.0",
+  "version": "14.2.1-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nw-style-guide",
-      "version": "14.2.0",
+      "version": "14.2.1-beta.4",
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nw-style-guide",
-  "version": "14.2.1-beta.4",
+  "version": "14.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nw-style-guide",
-      "version": "14.2.1-beta.4",
+      "version": "14.2.1",
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-style-guide",
-  "version": "14.2.1-beta.0",
+  "version": "14.2.1-beta.2",
   "license": "MIT",
   "author": {
     "email": "garethdn@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-style-guide",
-  "version": "14.2.1-beta.3",
+  "version": "14.2.1-beta.4",
   "license": "MIT",
   "author": {
     "email": "garethdn@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-style-guide",
-  "version": "14.2.0",
+  "version": "14.2.1-beta.0",
   "license": "MIT",
   "author": {
     "email": "garethdn@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-style-guide",
-  "version": "14.2.1-beta.4",
+  "version": "14.2.1",
   "license": "MIT",
   "author": {
     "email": "garethdn@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-style-guide",
-  "version": "14.2.1-beta.2",
+  "version": "14.2.1-beta.3",
   "license": "MIT",
   "author": {
     "email": "garethdn@gmail.com",

--- a/src/_lib/modules/dropdowns/dropdown-toggle.directive.ts
+++ b/src/_lib/modules/dropdowns/dropdown-toggle.directive.ts
@@ -14,7 +14,6 @@ import { Subscription, fromEvent } from 'rxjs';
 export class DropdownToggleDirective implements OnInit, OnDestroy {
 
     @Input() nwTrigger: "click" | "hover" = "click";
-    @Input() isResponsive: boolean = true;
     @Input() breakpoint: number = 767;
 
     public isOpen: boolean = false;
@@ -33,17 +32,19 @@ export class DropdownToggleDirective implements OnInit, OnDestroy {
         if (this.nwTrigger === 'hover') {
             const mouseEnterSub: Subscription = fromEvent(this._elRef.nativeElement as HTMLElement, 'mouseenter')
                 .pipe(
+                    filter(_ => !this._isMobile()),
                     tap(_ => this._isMousingOver = true),
                     debounceTime(300),
-                    filter(_ => this._isMousingOver && this._canHover())
+                    filter(_ => this._isMousingOver)
                 )
                 .subscribe(event => this._open());
 
             const mouseLeaveSub: Subscription = fromEvent(this._elRef.nativeElement as HTMLElement, 'mouseleave')
                 .pipe(
+                    filter(_ => !this._isMobile()),
                     tap(_ => this._isMousingOver = false),
                     debounceTime(300),
-                    filter(_ => !this._isMousingOver && this._canHover())
+                    filter(_ => !this._isMousingOver)
                 )
                 .subscribe(event => this._close());
 
@@ -51,11 +52,8 @@ export class DropdownToggleDirective implements OnInit, OnDestroy {
         }
     }
 
-    private _canHover() {
-        if (!this.isResponsive) {
-            return true;
-        }
-        return this.isResponsive && window.innerWidth > this.breakpoint;
+    private _isMobile() {
+        return window.innerWidth < this.breakpoint;
     }
 
     private _subscribeToToggle() {

--- a/src/_lib/modules/dropdowns/dropdown-toggle.directive.ts
+++ b/src/_lib/modules/dropdowns/dropdown-toggle.directive.ts
@@ -77,7 +77,9 @@ export class DropdownToggleDirective implements OnInit, OnDestroy {
     @HostListener('click', ['$event'])
     toggle(event: MouseEvent) {
         this._service.toggle();
-        event.stopImmediatePropagation();
+        if (this.nwTrigger === 'hover') {
+            event.stopImmediatePropagation();
+        }
     }
 
     ngOnDestroy() {

--- a/src/_lib/modules/dropdowns/dropdown-toggle.directive.ts
+++ b/src/_lib/modules/dropdowns/dropdown-toggle.directive.ts
@@ -32,7 +32,7 @@ export class DropdownToggleDirective implements OnInit, OnDestroy {
         if (this.nwTrigger === 'hover') {
             const mouseEnterSub: Subscription = fromEvent(this._elRef.nativeElement as HTMLElement, 'mouseenter')
                 .pipe(
-                    filter(_ => !this._isMobile()),
+                    filter(_ => !this._isMobileScreenSize()),
                     tap(_ => this._isMousingOver = true),
                     debounceTime(300),
                     filter(_ => this._isMousingOver)
@@ -41,7 +41,7 @@ export class DropdownToggleDirective implements OnInit, OnDestroy {
 
             const mouseLeaveSub: Subscription = fromEvent(this._elRef.nativeElement as HTMLElement, 'mouseleave')
                 .pipe(
-                    filter(_ => !this._isMobile()),
+                    filter(_ => !this._isMobileScreenSize()),
                     tap(_ => this._isMousingOver = false),
                     debounceTime(300),
                     filter(_ => !this._isMousingOver)
@@ -52,7 +52,7 @@ export class DropdownToggleDirective implements OnInit, OnDestroy {
         }
     }
 
-    private _isMobile() {
+    private _isMobileScreenSize() {
         return window.innerWidth < this.breakpoint;
     }
 

--- a/src/app/dropdowns/dropdowns.component.html
+++ b/src/app/dropdowns/dropdowns.component.html
@@ -3,7 +3,14 @@
 
     <h3>Usage</h3>
 
-    <pre><code>{{"import \{ DropdownsModule \} from 'nw-style-guide/dropdowns';
+    <p>
+        Import <code>DropdownsModule</code> to your imports in AppModule. 
+        If it it's being used in a standalone component import into the components imports array
+    </p>
+
+    <hr>
+
+    <!-- <pre><code>{{"import \{ DropdownsModule \} from 'nw-style-guide/dropdowns';
 
 ...........
 ...........
@@ -17,7 +24,9 @@
     ],
     bootstrap: [AppComponent]
 })
-export class AppModule \{ \}"}}</code></pre>
+export class AppModule \{ \}"}}
+
+</code></pre> -->
 
     <h3>Color variations</h3>
 
@@ -361,7 +370,6 @@ export class AppModule \{ \}"}}</code></pre>
     <hr>
 
     <h3>Dropdown full width</h3>
-
     <div class="full-width-container">
         <div class="dropdown" nwDropdown>
             <div class="dropdown-backdrop"></div>
@@ -399,6 +407,25 @@ export class AppModule \{ \}"}}</code></pre>
     <em>
         <code>.dropdown-menu-block</code> will make the dropdown menu the same width as the parent container
     </em>
+
+    <hr>
+
+    <h3>Responsive</h3>
+    <p>Mouse hover events don't exist on mobile.  If nwTrigger is set to hover, this will be set to click when the screen goes below a specific size</p>
+    <em><i class="fas fa-exclamation-circle"></i> Defualt size is <code>767</code></em>
+
+
+    <div class="full-width-container mt-16">
+        <div class="dropdown" nwDropdown>
+            <button class="btn btn-secondary btn-block dropdown-toggle" type="button" nwDropdownToggle nwTrigger="hover">
+                Hover on large screen, click on small screen
+                <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" nwDropdownMenu>
+                <li><a href="#">Menu item 1</a></li>
+            </ul>
+        </div>
+    </div>
 
     <hr>
 

--- a/src/app/dropdowns/dropdowns.component.html
+++ b/src/app/dropdowns/dropdowns.component.html
@@ -5,28 +5,10 @@
 
     <p>
         Import <code>DropdownsModule</code> to your imports in AppModule. 
-        If it it's being used in a standalone component import into the components imports array
+        If it's being used in a standalone component import into the components imports array
     </p>
 
     <hr>
-
-    <!-- <pre><code>{{"import \{ DropdownsModule \} from 'nw-style-guide/dropdowns';
-
-...........
-...........
-
-@NgModule({
-    declarations: [...],
-    imports: [
-        .....
-        .....
-        DropdownsModule
-    ],
-    bootstrap: [AppComponent]
-})
-export class AppModule \{ \}"}}
-
-</code></pre> -->
 
     <h3>Color variations</h3>
 


### PR DESCRIPTION
**The Issue**
Mobile doesn't have a hover event, so any submenus triggered by hover won't work properly.   This isn't much of an issue on an actual mobile, but on a desktop responsive view, the `mouseeneter` and `mouseleave` are still fired, but only after clicking on the element.   

**The Solution**
Disable the hover if the window width is less than the `breakpoint` value (default 767).   Putting the check in the rxjs pipe rather than in `ngOnInit` means it avoids the issue where the desktop browser is still receiving events, and it will also respond to screen resize - no need to refresh the browser

https://newswhip.atlassian.net/browse/RDN-917