### PR TITLE
Github pages 404

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -69,6 +69,30 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ]
+            },
+            "ghpages": {
+              "outputPath": {
+                "base": "docs",
+                "browser": ""
+              },
+              "baseHref": "/style-guide/",
+              "budgets": [
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": ""

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "ngc": "ngc",
-    "ghpages": "ng build --configuration production --output-path docs  --base-href /style-guide/",
+    "ghpages": "ng build --configuration ghpages",
     "g:m": "ng g module --app=1",
     "g:c": "ng g component --app=1",
     "g:d": "ng g directive --app=1",


### PR DESCRIPTION
since changing to vite, by default the build output to an extra /browser directory. reset this