### PR TITLE
Lazily create the tooltip overlay on first open

### DIFF
--- a/projects/nw-style-guide/package.json
+++ b/projects/nw-style-guide/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nw-style-guide",
     "type": "module",
-    "version": "21.2.1",
+    "version": "21.2.2-beta.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/NewsWhip/style-guide"

--- a/projects/nw-style-guide/package.json
+++ b/projects/nw-style-guide/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nw-style-guide",
     "type": "module",
-    "version": "21.2.3-beta.0",
+    "version": "21.2.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/NewsWhip/style-guide"

--- a/projects/nw-style-guide/tooltips/tooltip.directive.ts
+++ b/projects/nw-style-guide/tooltips/tooltip.directive.ts
@@ -120,7 +120,7 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
     @Output() nwHidden: EventEmitter<null> = new EventEmitter();
     @Output() nwClose: EventEmitter<null> = new EventEmitter();
 
-    private _overlayRef: OverlayRef;
+    private _overlayRef: OverlayRef | null = null;
     private _destroyed$: Subject<void> = new Subject();
     private _tooltipArrowSize: number = 5;
     private _manualToggleEvent$: Subject<boolean> = new Subject();
@@ -129,10 +129,10 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
      * A subject that emits when the TooltipContainerComponent is destroyed
      */
     private _tooltipContainerDestroyed$: Subject<void> = new Subject();
+    private _outsideClick$: Subject<boolean> = new Subject();
 
     ngOnInit() {
         this._setInputDefaults();
-        this._createOverlay();
         this._subscribeToEvents();
 
         if (this.isOpen) {
@@ -142,11 +142,11 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
         if (this.updatePositionOnAnimationFrame) {
             interval(0, animationFrameScheduler)
                 .pipe(
-                    filter(_ => this.updatePositionOnAnimationFrame && this._overlayRef.hasAttached()),
+                    filter(_ => this.updatePositionOnAnimationFrame && this._overlayRef?.hasAttached()),
                     takeUntil(this._destroyed$)
                 )
                 .subscribe(() => {
-                    this._overlayRef.updatePosition();
+                    this._overlayRef?.updatePosition();
                 });
         }
     }
@@ -159,11 +159,11 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
         const shouldUpdateScrollStrategy: boolean =
             c.closeOnScroll?.previousValue !== c.closeOnScroll?.currentValue && !c.closeOnScroll.firstChange;
 
-        if (shouldUpdatePositionStrategy) {
+        if (shouldUpdatePositionStrategy && this._overlayRef) {
             this._updatePositionStrategy(this.placement);
         }
 
-        if (shouldUpdateScrollStrategy) {
+        if (shouldUpdateScrollStrategy && this._overlayRef) {
             this._updateScrollStrategy(this.closeOnScroll);
         }
 
@@ -190,7 +190,7 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
      * Can be called manually from the exported directive to toggle the tooltip
      */
     toggle(): void {
-        const isOpen = this._overlayRef.hasAttached();
+        const isOpen = this._overlayRef?.hasAttached();
         this._manualToggleEvent$.next(!isOpen);
     }
 
@@ -230,6 +230,22 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
     }
 
     private _open(): ComponentRef<TooltipContainerComponent> {
+        if (!this._overlayRef) {
+            /**
+             * Create the overlay the first time the tooltip is opened
+             */
+            this._createOverlay();
+
+            if (this.closeOnOutsideClick) {
+                this._overlayRef.outsidePointerEvents().pipe(
+                    filter(_ => this._overlayRef?.hasAttached()),
+                    filter(event => event.target !== this._elRef.nativeElement),
+                    map(_ => false),
+                    takeUntil(this._destroyed$)
+                ).subscribe(v => this._outsideClick$.next(v));
+            }
+        }
+
         if (!this._overlayRef.hasAttached()) {
             const portal = new ComponentPortal(TooltipContainerComponent, this._vcRef, this._createInjector());
             const ref = this._overlayRef.attach(portal);
@@ -239,7 +255,7 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
     }
 
     private _close(): void {
-        if (this._overlayRef.hasAttached()) {
+        if (this._overlayRef?.hasAttached()) {
             this._overlayRef.detach();
             this.nwHidden.emit();
         }
@@ -283,7 +299,7 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
     private _subscribeToEvents() {
         const openEvents$: Observable<boolean>[] = this.openEvents.map(eventName => {
             return fromEvent(this._elRef.nativeElement, eventName).pipe(
-                filter(_ => !this._overlayRef.hasAttached()),
+                filter(_ => !this._overlayRef?.hasAttached()),
                 map(_ => true)
             );
         });
@@ -291,19 +307,12 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
         const closeEvents$: Observable<boolean>[] = this.closeEvents.map(eventName => {
             return fromEvent(this._elRef.nativeElement, eventName).pipe(
                 tap(_ => this._cancelDelayedOpen$.next()),
-                filter(_ => this._overlayRef.hasAttached()),
+                filter(_ => this._overlayRef?.hasAttached()),
                 map(_ => false)
             );
         });
 
-        const outsideClick$: Observable<boolean> = this.closeOnOutsideClick
-            ? this._overlayRef.outsidePointerEvents().pipe(
-                  filter(_ => this._overlayRef.hasAttached()),
-                  // The element that this tooltip is attached to should not be included as an outside click
-                  filter(event => event.target !== this._elRef.nativeElement),
-                  map(_ => false)
-              )
-            : EMPTY;
+        const outsideClick$: Observable<boolean> = this.closeOnOutsideClick ? this._outsideClick$.asObservable() : EMPTY;
 
         /**
          * Merge all open and close events into a single stream that emits a boolean that indicates whether
@@ -555,6 +564,6 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
         this.hide();
         this._destroyed$.next();
         this._destroyed$.complete();
-        this._overlayRef.dispose();
+        this._overlayRef?.dispose();
     }
 }

--- a/projects/nw-style-guide/tooltips/tooltip.directive.ts
+++ b/projects/nw-style-guide/tooltips/tooltip.directive.ts
@@ -237,12 +237,15 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
             this._createOverlay();
 
             if (this.closeOnOutsideClick) {
-                this._overlayRef.outsidePointerEvents().pipe(
-                    filter(_ => this._overlayRef?.hasAttached()),
-                    filter(event => event.target !== this._elRef.nativeElement),
-                    map(_ => false),
-                    takeUntil(this._destroyed$)
-                ).subscribe(v => this._outsideClick$.next(v));
+                this._overlayRef
+                    .outsidePointerEvents()
+                    .pipe(
+                        filter(_ => this._overlayRef?.hasAttached()),
+                        filter(event => event.target !== this._elRef.nativeElement),
+                        map(_ => false),
+                        takeUntil(this._destroyed$)
+                    )
+                    .subscribe(v => this._outsideClick$.next(v));
             }
         }
 
@@ -312,7 +315,9 @@ export class TooltipDirective implements OnInit, OnChanges, OnDestroy {
             );
         });
 
-        const outsideClick$: Observable<boolean> = this.closeOnOutsideClick ? this._outsideClick$.asObservable() : EMPTY;
+        const outsideClick$: Observable<boolean> = this.closeOnOutsideClick
+            ? this._outsideClick$.asObservable()
+            : EMPTY;
 
         /**
          * Merge all open and close events into a single stream that emits a boolean that indicates whether

--- a/src/app/tooltips/tooltips.component.html
+++ b/src/app/tooltips/tooltips.component.html
@@ -376,113 +376,114 @@
     </div>
 }
 
-<div
-    *ngIf="selectedTab === 'api'"
-    class="tab-content">
-    <h3>API reference for tooltips / popover</h3>
-    <app-code [snippet]="snippets.import"></app-code>
-
-    <h4>Directives</h4>
-
-    <h5><code>TooltipDirective</code></h5>
-    <p>Directive that attaches a tooltip / popover to the host element.</p>
-    <p>Selector: <code>[nwTooltip],[nwPopover]</code></p>
-    <p>Exported as: <code>nw-tooltip,nw-popover</code></p>
-    <small
-        >This directive can be invoked by using the <code>nwTooltip</code> or <code>nwPopover</code> attributes. The
-        only differences between using these attributes are the default values of certain properties, e.g. `delay` and
-        open and close events</small
-    >
-    <h5>Properties</h5>
-
-    <table class="table table-bordered">
-        <thead>
-            <tr>
-                <th rowspan="2">Name</th>
-                <th rowspan="2">Description</th>
-                <th colspan="2">Default values</th>
-            </tr>
-            <tr>
-                <th><code style="text-transform: initial">nwTooltip</code></th>
-                <th><code style="text-transform: initial">nwPopover</code></th>
-            </tr>
-        </thead>
-
-        <tbody>
-            <ng-container *ngFor="let row of propertiesTable">
-                <ng-container *ngTemplateOutlet="inputTableTowTmpl; context: { values: row }"></ng-container>
-            </ng-container>
-        </tbody>
-    </table>
-
-    <h5>Methods</h5>
-
-    <table class="table table-bordered">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Description</th>
-            </tr>
-        </thead>
-
-        <tbody>
-            <tr>
-                <td>
-                    <code class="light">{{ 'show(): void' }}</code>
-                </td>
-                <td>Can be called manually from the exported directive to open the tooltip</td>
-            </tr>
-
-            <tr>
-                <td>
-                    <code class="light">{{ 'hide(): void' }}</code>
-                </td>
-                <td>Can be called manually from the exported directive to close the tooltip</td>
-            </tr>
-
-            <tr>
-                <td>
-                    <code class="light">{{ 'toggle(): void' }}</code>
-                </td>
-                <td>Can be called manually from the exported directive to toggle the tooltip</td>
-            </tr>
-        </tbody>
-    </table>
-
-    <h5>Types and interfaces</h5>
-    <app-code [snippet]="snippets.placementType"></app-code>
-
-    <h4>Troubleshooting</h4>
-
-    <app-faq>
-        <p question>My tooltip is not closing on scroll even though I've set <code>[closeOnScroll]="true"</code>.</p>
-        <p answer>
-            If your tooltip is inside a scrollable container, that scrollable container needs to have the
-            <code>cdkScrollable</code> directive attached.
-        </p>
-    </app-faq>
-
-    <app-faq>
-        <p question>My tooltip is not repositioning on scroll.</p>
-        <p answer>
-            As above, if your tooltip is inside a scrollable container, that scrollable container needs to have the
-            <code>cdkScrollable</code> directive attached.
-        </p>
-    </app-faq>
-
-    <app-faq>
-        <p question>Do I use the nwTooltip selector or the nwPopover selector?</p>
-        <p answer>
-            The answer depends on your desired behaviour. The only differences between the two selectors are the default
-            values of the inputs. Consult the properties table above to the differences between the default values.
-        </p>
-    </app-faq>
-
-    <app-faq>
-        <p question>How do I tweak the position of the tooltip?</p>
-        <p answer>You can supply a containerClass input which you can apply styles against.</p>
-    </app-faq>
-</div>
+@if (selectedTab === 'api') {
+    <div
+        class="tab-content">
+        <h3>API reference for tooltips / popover</h3>
+        <app-code [snippet]="snippets.import"></app-code>
+    
+        <h4>Directives</h4>
+    
+        <h5><code>TooltipDirective</code></h5>
+        <p>Directive that attaches a tooltip / popover to the host element.</p>
+        <p>Selector: <code>[nwTooltip],[nwPopover]</code></p>
+        <p>Exported as: <code>nw-tooltip,nw-popover</code></p>
+        <small
+            >This directive can be invoked by using the <code>nwTooltip</code> or <code>nwPopover</code> attributes. The
+            only differences between using these attributes are the default values of certain properties, e.g. `delay` and
+            open and close events</small
+        >
+        <h5>Properties</h5>
+    
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th rowspan="2">Name</th>
+                    <th rowspan="2">Description</th>
+                    <th colspan="2">Default values</th>
+                </tr>
+                <tr>
+                    <th><code style="text-transform: initial">nwTooltip</code></th>
+                    <th><code style="text-transform: initial">nwPopover</code></th>
+                </tr>
+            </thead>
+    
+            <tbody>
+                @for (row of propertiesTable; track $index) {
+                    <ng-container *ngTemplateOutlet="inputTableTowTmpl; context: { values: row }"></ng-container>
+                }
+            </tbody>
+        </table>
+    
+        <h5>Methods</h5>
+    
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+    
+            <tbody>
+                <tr>
+                    <td>
+                        <code class="light">{{ 'show(): void' }}</code>
+                    </td>
+                    <td>Can be called manually from the exported directive to open the tooltip</td>
+                </tr>
+    
+                <tr>
+                    <td>
+                        <code class="light">{{ 'hide(): void' }}</code>
+                    </td>
+                    <td>Can be called manually from the exported directive to close the tooltip</td>
+                </tr>
+    
+                <tr>
+                    <td>
+                        <code class="light">{{ 'toggle(): void' }}</code>
+                    </td>
+                    <td>Can be called manually from the exported directive to toggle the tooltip</td>
+                </tr>
+            </tbody>
+        </table>
+    
+        <h5>Types and interfaces</h5>
+        <app-code [snippet]="snippets.placementType"></app-code>
+    
+        <h4>Troubleshooting</h4>
+    
+        <app-faq>
+            <p question>My tooltip is not closing on scroll even though I've set <code>[closeOnScroll]="true"</code>.</p>
+            <p answer>
+                If your tooltip is inside a scrollable container, that scrollable container needs to have the
+                <code>cdkScrollable</code> directive attached.
+            </p>
+        </app-faq>
+    
+        <app-faq>
+            <p question>My tooltip is not repositioning on scroll.</p>
+            <p answer>
+                As above, if your tooltip is inside a scrollable container, that scrollable container needs to have the
+                <code>cdkScrollable</code> directive attached.
+            </p>
+        </app-faq>
+    
+        <app-faq>
+            <p question>Do I use the nwTooltip selector or the nwPopover selector?</p>
+            <p answer>
+                The answer depends on your desired behaviour. The only differences between the two selectors are the default
+                values of the inputs. Consult the properties table above to the differences between the default values.
+            </p>
+        </app-faq>
+    
+        <app-faq>
+            <p question>How do I tweak the position of the tooltip?</p>
+            <p answer>You can supply a containerClass input which you can apply styles against.</p>
+        </app-faq>
+    </div>
+}
 
 <ng-template
     #inputTableTowTmpl

--- a/src/app/tooltips/tooltips.component.html
+++ b/src/app/tooltips/tooltips.component.html
@@ -377,24 +377,23 @@
 }
 
 @if (selectedTab === 'api') {
-    <div
-        class="tab-content">
+    <div class="tab-content">
         <h3>API reference for tooltips / popover</h3>
         <app-code [snippet]="snippets.import"></app-code>
-    
+
         <h4>Directives</h4>
-    
+
         <h5><code>TooltipDirective</code></h5>
         <p>Directive that attaches a tooltip / popover to the host element.</p>
         <p>Selector: <code>[nwTooltip],[nwPopover]</code></p>
         <p>Exported as: <code>nw-tooltip,nw-popover</code></p>
         <small
             >This directive can be invoked by using the <code>nwTooltip</code> or <code>nwPopover</code> attributes. The
-            only differences between using these attributes are the default values of certain properties, e.g. `delay` and
-            open and close events</small
+            only differences between using these attributes are the default values of certain properties, e.g. `delay`
+            and open and close events</small
         >
         <h5>Properties</h5>
-    
+
         <table class="table table-bordered">
             <thead>
                 <tr>
@@ -407,16 +406,16 @@
                     <th><code style="text-transform: initial">nwPopover</code></th>
                 </tr>
             </thead>
-    
+
             <tbody>
                 @for (row of propertiesTable; track $index) {
                     <ng-container *ngTemplateOutlet="inputTableTowTmpl; context: { values: row }"></ng-container>
                 }
             </tbody>
         </table>
-    
+
         <h5>Methods</h5>
-    
+
         <table class="table table-bordered">
             <thead>
                 <tr>
@@ -424,7 +423,7 @@
                     <th>Description</th>
                 </tr>
             </thead>
-    
+
             <tbody>
                 <tr>
                     <td>
@@ -432,14 +431,14 @@
                     </td>
                     <td>Can be called manually from the exported directive to open the tooltip</td>
                 </tr>
-    
+
                 <tr>
                     <td>
                         <code class="light">{{ 'hide(): void' }}</code>
                     </td>
                     <td>Can be called manually from the exported directive to close the tooltip</td>
                 </tr>
-    
+
                 <tr>
                     <td>
                         <code class="light">{{ 'toggle(): void' }}</code>
@@ -448,20 +447,22 @@
                 </tr>
             </tbody>
         </table>
-    
+
         <h5>Types and interfaces</h5>
         <app-code [snippet]="snippets.placementType"></app-code>
-    
+
         <h4>Troubleshooting</h4>
-    
+
         <app-faq>
-            <p question>My tooltip is not closing on scroll even though I've set <code>[closeOnScroll]="true"</code>.</p>
+            <p question>
+                My tooltip is not closing on scroll even though I've set <code>[closeOnScroll]="true"</code>.
+            </p>
             <p answer>
                 If your tooltip is inside a scrollable container, that scrollable container needs to have the
                 <code>cdkScrollable</code> directive attached.
             </p>
         </app-faq>
-    
+
         <app-faq>
             <p question>My tooltip is not repositioning on scroll.</p>
             <p answer>
@@ -469,15 +470,16 @@
                 <code>cdkScrollable</code> directive attached.
             </p>
         </app-faq>
-    
+
         <app-faq>
             <p question>Do I use the nwTooltip selector or the nwPopover selector?</p>
             <p answer>
-                The answer depends on your desired behaviour. The only differences between the two selectors are the default
-                values of the inputs. Consult the properties table above to the differences between the default values.
+                The answer depends on your desired behaviour. The only differences between the two selectors are the
+                default values of the inputs. Consult the properties table above to the differences between the default
+                values.
             </p>
         </app-faq>
-    
+
         <app-faq>
             <p question>How do I tweak the position of the tooltip?</p>
             <p answer>You can supply a containerClass input which you can apply styles against.</p>


### PR DESCRIPTION
https://sprout.atlassian.net/browse/APP-684

## Summary

Previously, `TooltipDirective` created its CDK overlay in `ngOnInit`, meaning every tooltip on the page would allocate an overlay ref (and attach outside-click listeners) regardless of whether the tooltip was ever opened.

This PR defers overlay creation to the first time `_open()` is called, reducing unnecessary DOM/overlay work for tooltips that are never shown.

## Changes

- `_overlayRef` is initialised to `null` and created lazily inside `_open()` on the first call.
- The `closeOnOutsideClick` pointer-events subscription is set up at the same time (also lazily), replacing the version that was wired up eagerly in `_subscribeToEvents`.
- All call sites that previously assumed `_overlayRef` was always set now use optional chaining (`?.`).
