### PR TITLE
App 728 focus styles checkbox and button

### DIFF
--- a/projects/nw-style-guide/package.json
+++ b/projects/nw-style-guide/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nw-style-guide",
     "type": "module",
-    "version": "21.2.6",
+    "version": "21.2.7",
     "repository": {
         "type": "git",
         "url": "https://github.com/NewsWhip/style-guide"

--- a/projects/nw-style-guide/src/lib/sass/src/_buttons.scss
+++ b/projects/nw-style-guide/src/lib/sass/src/_buttons.scss
@@ -175,6 +175,9 @@ a.btn {
     &:hover {
         text-decoration: underline;
     }
+    &:active {
+        border: none;
+    }
 }
 
 // Button Sizes

--- a/projects/nw-style-guide/src/lib/sass/src/_forms.scss
+++ b/projects/nw-style-guide/src/lib/sass/src/_forms.scss
@@ -283,9 +283,11 @@ input[type='search'] {
                 opacity: 0.5;
             }
         }
-        &:focus {
+
+        &:focus-visible {
             ~ label:before {
-                @include forms.form-control-focus(variables.$input-border-focus, 2px);
+                outline: 2px solid variables.get-color('primary', base);
+                outline-offset: 2px;
             }
         }
     }

--- a/projects/nw-style-guide/src/lib/sass/src/_type.scss
+++ b/projects/nw-style-guide/src/lib/sass/src/_type.scss
@@ -274,6 +274,7 @@ blockquote {
 }
 
 .nw-link-inline {
+    text-decoration: underline;
     &:visited,
     &.visited {
         color: variables.$text-color-secondary;


### PR DESCRIPTION
### Summary of changes
- Remove the active ring around a btn-link when clicked <img width="80" height="44" alt="Screenshot 2026-06-10 at 13 52 02" src="https://github.com/user-attachments/assets/b755d17f-ebfd-460f-b802-1db12abff930" />
- Inline links should have an underline https://sprout.atlassian.net/browse/APP-668
- remove click focus ring on checkboxes and radio buttons