### PR TITLE
APP-701 publish pre-releases with matching npm dist-tag

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -5,7 +5,7 @@ import * as utils from '../utils.js';
 
 const ALLOWED_PRERELEASE_TAGS = ['alpha', 'beta', 'rc'];
 
-const resolveDistTag = (version) => {
+const resolveDistTag = version => {
     const prerelease = version.split('-')[1];
     if (!prerelease) return null;
 
@@ -22,9 +22,7 @@ const resolveDistTag = (version) => {
 const run = async () => {
     await import('./build.js');
 
-    const { version } = JSON.parse(
-        fs.readFileSync(path.join(utils.distPath, 'package.json'), 'utf8')
-    );
+    const { version } = JSON.parse(fs.readFileSync(path.join(utils.distPath, 'package.json'), 'utf8'));
     const tag = resolveDistTag(version);
     const tagFlag = tag ? `--tag ${tag}` : '';
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,10 +1,34 @@
 import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
 import * as utils from '../utils.js';
+
+const ALLOWED_PRERELEASE_TAGS = ['alpha', 'beta', 'rc'];
+
+const resolveDistTag = (version) => {
+    const prerelease = version.split('-')[1];
+    if (!prerelease) return null;
+
+    const identifier = prerelease.split('.')[0];
+    if (!ALLOWED_PRERELEASE_TAGS.includes(identifier)) {
+        throw new Error(
+            `Unrecognised pre-release identifier "${identifier}" in version "${version}". ` +
+                `Expected one of: ${ALLOWED_PRERELEASE_TAGS.join(', ')}.`
+        );
+    }
+    return identifier;
+};
 
 const run = async () => {
     await import('./build.js');
 
-    process.stdout.write('Publishing package \n');
+    const { version } = JSON.parse(
+        fs.readFileSync(path.join(utils.distPath, 'package.json'), 'utf8')
+    );
+    const tag = resolveDistTag(version);
+    const tagFlag = tag ? `--tag ${tag}` : '';
+
+    process.stdout.write(`Publishing ${version} with dist-tag "${tag ?? 'latest'}" \n`);
 
     try {
         /**
@@ -14,7 +38,7 @@ const run = async () => {
          * ref: https://nodejs.org/api/child_process.html#optionsstdio
          * ref: https://stackoverflow.com/a/31104898/1128290
          */
-        execSync(`npm publish ${utils.distPath}`, {
+        execSync(`npm publish ${utils.distPath} ${tagFlag}`, {
             stdio: 'inherit'
         });
     } catch (err) {


### PR DESCRIPTION
## Summary
- Inspects the built package version in `lib-dist/nw-style-guide/package.json` and derives an npm dist-tag from the SemVer pre-release identifier (`alpha` / `beta` / `rc`)
- Appends `--tag <tag>` to `npm publish` for pre-releases so they are not surfaced under `latest`
- Stable SemVer versions publish with the default `latest` tag; any unrecognised pre-release identifier aborts before publishing with a clear error

Jira: [APP-701](https://sprout.atlassian.net/browse/APP-701)

## Test plan
- [x] With `projects/nw-style-guide/package.json` version `X.Y.Z-beta.0`, run the publish path under `npm publish --dry-run` and confirm npm reports `Tag: beta`
- [x] Repeat with `-alpha.0` and `-rc.1` versions, confirm matching tags
- [x] Clean SemVer `X.Y.Z` publishes with no `--tag` flag (defaults to `latest`)
- [x] An unsupported identifier (e.g. `X.Y.Z-experimental.0`) aborts with the expected error before `npm publish` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)