### PR TITLE
bump node version in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
                   fetch-depth: 0
             - uses: actions/setup-node@v4
               with:
-                  node-version: 22.16
+                  node-version: 22
             - name: Release
               uses: justincy/github-action-npm-release@2.0.2
               id: release

--- a/projects/nw-style-guide/package.json
+++ b/projects/nw-style-guide/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nw-style-guide",
     "type": "module",
-    "version": "21.2.9",
+    "version": "21.2.10",
     "repository": {
         "type": "git",
         "url": "https://github.com/NewsWhip/style-guide"


### PR DESCRIPTION
### Why?  

From Claude

> ⏺ Here's the timeline:                                                                                                                                                                                                   
                                                                                                                                                                                                                        
>   - March 24, 2026 — Node.js 22.22.2 was released (a security patch)                                                                                                                                                     
>   - July 8, 2026 — npm 12.0.0 shipped, with its engine requirement set to ^22.22.2 || ^24.15.0 || >=26.0.0                                                                                                               
>                                                                                                                                                                                                                          
>   Your workflow has pinned node-version: 22.16 since September 2025, which predates both of these. It worked fine until npm 12 dropped last week — npm would have been auto-updated to v12 on the next run, at which     
>   point it refused to start because 22.16 < 22.22.2.                                                                                                                                                                     
> 
>   In short: the pin was always stale, but it only became a breaking problem when npm 12 raised the minimum Node requirement above 22.16.
> 
>   Sources:
>   - Release v12.0.0 · npm/cli
>   - Release 2026-03-24, Version 22.22.2 · nodejs/node
>   - Changelog | npm Docs